### PR TITLE
fit for android-gradle-plugin3.0.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ```groovy
 dependencies {
    ...
-   classpath 'me.ele:mess-plugin:1.1.3'
+   classpath 'me.ele:mess-plugin:1.1.4'
  }
   
 apply plugin: 'com.android.library'
@@ -33,6 +33,8 @@ mess {
     ignoreProguard 'com.jakewharton:butterknife'
 }
 ```
+
+If you are using AAPT2, please disable AAPT2 by setting `android.enableAapt2=false` in your gradle.properties file.
 
 As a result, the Butter Knife's proguard configuration will be ignored. And those activities, views, fragments will be obfuscated by Mess.
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,11 @@
 
 buildscript {
     repositories {
+        maven { url 'https://maven.google.com' }
         jcenter()
     }
     dependencies {
+//        classpath 'com.android.tools.build:gradle:3.0.0-beta5'
         classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -53,7 +53,7 @@ publishing {
       from components.java
       groupId 'me.ele'
       artifactId 'mess-plugin'
-      version '1.1.3'
+      version '1.1.4'
 
       pom.withXml {
         def root = asNode()
@@ -89,7 +89,7 @@ try {
       licenses = ['Apache-2.0']
       vcsUrl = 'https://github.com/bintray/gradle-bintray-plugin.git'
       version {
-        name = '1.1.3'
+        name = '1.1.4'
         attributes = ['gradle-plugin': 'Mess:me.ele:mess-plugin']
       }
     }

--- a/buildSrc/src/main/groovy/me/ele/mess/RewriteComponentTask.groovy
+++ b/buildSrc/src/main/groovy/me/ele/mess/RewriteComponentTask.groovy
@@ -56,13 +56,16 @@ class RewriteComponentTask extends DefaultTask {
 
         // AndroidManifest.xml
         map.each { k, v ->
-            String realPath = variantOutput.processManifest.manifestOutputFile
+            String realPath = "${project.buildDir.absolutePath}/intermediates/manifests/full/${getSubResPath()}/AndroidManifest.xml"
             writeLine(realPath, k, v)
         }
 
         long t0 = System.currentTimeMillis()
         File resDir = new File(getResPath())
         resDir.eachFile { File dir ->
+            if (dir.isFile() && dir.name.endsWith(".flat")) {
+                throw new Exception("please disable AAPT2 by setting `android.enableAapt2=false` in your gradle.properties file.")
+            }
             if (dir.exists() && dir.isDirectory() && isLayoutsDir(dir.name)) {
                 dir.eachFileRecurse(FileType.FILES) { File file ->
                     String orgTxt = file.getText(CHARSET)


### PR DESCRIPTION
cc @JackCho 

gradle3.0+ 会默认使用AAPT2，导致 `build/intermediates/res/merged` 行为发生变化，所以需要禁用AAPT2